### PR TITLE
Implement post_parse_callback for option groups

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,0 +1,8 @@
+# Fork Changelog
+
+List of changes made to [connormason/cloup](https://github.com/connormason/cloup) that diverge from the default
+[cloup](https://github.com/janluke/cloup) library
+
+## Option Groups
+- Option groups accept a `post_parse_callback`, which is run after arguments are parsed, and allows manipulation of the
+context. This is useful for more complicated option group factories

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -53,7 +53,8 @@ ClickGroup = TypeVar('ClickGroup', bound=click.Group)
 
 
 class Command(ConstraintMixin, OptionGroupMixin, click.Command):
-    """A ``click.Command`` supporting option groups and constraints.
+    """
+    A ``click.Command`` supporting option groups and constraints.
 
     Refer to superclasses for the documentation of all accepted parameters:
 

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -169,6 +169,7 @@ class ConstraintMixin:
         """All constraints applied to parameter/option groups of this command."""
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+
         # Check constraints' consistency *before* parsing
         if not ctx.resilient_parsing and Constraint.must_check_consistency(ctx):
             for constr in self.all_constraints:


### PR DESCRIPTION
This allows for more complicated option group factories by letting an option group manipulate the context after arguments are parsed