### PR TITLE
Allow arguments to be hidden

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -3,6 +3,18 @@
 List of changes made to [connormason/cloup](https://github.com/connormason/cloup) that diverge from the default
 [cloup](https://github.com/janluke/cloup) library
 
+## Context Defaults
+- The help text can be accessed with `-h` or `--help` by default (instead of just `-h`). This can be overridden by
+providing the `help_option_names` context option
+- The maximum content width of help text is 500 (so it fills the whole width of the terminal). This can be overridden
+by providing the `max_content_width` context option
+
+## Arguments
+- Arguments accept `hidden` arg, which determines if the arg is hidden from the "Positional arguments" help text
+section. By default, the "Positional arguments" section is only displayed if any command arg has `help` text. `hidden`
+will override this behavior (`hidden=True` will hide args with help text, `hidden=False` will show args with no help
+text)
+
 ## Option Groups
 - Option groups accept a `post_parse_callback`, which is run after arguments are parsed, and allows manipulation of the
 context. This is useful for more complicated option group factories

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -1,24 +1,40 @@
 from __future__ import annotations
 
+from typing import Any
+from typing import Callable
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import Union
+
 import click
 from click.decorators import _param_memo
 
+if TYPE_CHECKING:
+    from cloup import Context
+    from cloup._commands import Command
+    from cloup._option_groups import OptionGroup
+
+
+FC = TypeVar('FC', bound=Union[Callable[..., Any], 'Command'])
+
 
 class Argument(click.Argument):
-    """A :class:`click.Argument` with help text."""
-
-    def __init__(self, *args, help=None, **attrs):
+    """
+    A :class:`click.Argument` with help text.
+    """
+    def __init__(self, *args: Any, help: str | None = None, **attrs: Any):
         super().__init__(*args, **attrs)
         self.help = help
 
-    def get_help_record(self, ctx):
+    def get_help_record(self, ctx: Context) -> tuple[str, str]:
         return self.make_metavar(), self.help or ''
 
 
 class Option(click.Option):
-    """A :class:`click.Option` with an extra field ``group`` of type ``OptionGroup``."""
-
-    def __init__(self, *args, group=None, **attrs):
+    """
+    A :class:`click.Option` with an extra field ``group`` of type ``OptionGroup``.
+    """
+    def __init__(self, *args: Any, group: OptionGroup | None = None, **attrs: Any):
         super().__init__(*args, **attrs)
         self.group = group
 
@@ -27,7 +43,11 @@ GroupedOption = Option
 """Alias of ``Option``."""
 
 
-def argument(*param_decls, cls=None, **attrs):
+def argument(
+    *param_decls: str,
+    cls: type[click.Argument] | None = None,
+    **attrs: Any
+) -> Callable[[FC], FC]:
     ArgumentClass = cls or Argument
 
     def decorator(f):
@@ -37,8 +57,14 @@ def argument(*param_decls, cls=None, **attrs):
     return decorator
 
 
-def option(*param_decls, cls=None, group=None, **attrs):
-    """Attach an ``Option`` to the command.
+def option(
+    *param_decls: str,
+    cls: type[click.Option] | None = None,
+    group: OptionGroup | None = None,
+    **attrs: Any
+) -> Callable[[FC], FC]:
+    """
+    Attach an ``Option`` to the command.
     Refer to :class:`click.Option` and :class:`click.Parameter` for more info
     about the accepted parameters.
 

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -21,10 +21,22 @@ FC = TypeVar('FC', bound=Union[Callable[..., Any], 'Command'])
 class Argument(click.Argument):
     """
     A :class:`click.Argument` with help text.
+
+    :param help: help text shown next to argument
+    :param hidden: hide this argument from help output. If the argument has no help text, it is hidden by default, and
+                   setting this to True will show it. If the argument has help text, it is shown by default, and setting
+                   this to False will hide it
     """
-    def __init__(self, *args: Any, help: str | None = None, **attrs: Any):
+    def __init__(
+        self,
+        *args: Any,
+        help: str | None = None,
+        hidden: bool | None = None,
+        **attrs: Any
+    ):
         super().__init__(*args, **attrs)
         self.help = help
+        self.hidden = hidden
 
     def get_help_record(self, ctx: Context) -> tuple[str, str]:
         return self.make_metavar(), self.help or ''


### PR DESCRIPTION
This allows arguments to provide `hidden=True` or `hidden=False` explicitly

By default, the "Positional arguments" section is only displayed if any command arg has `help` text. `hidden`
will override this behavior (`hidden=True` will hide args with help text, `hidden=False` will show args with no help
text)