### PR TITLE
Allow options to consume arbitrary number of values

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -15,6 +15,9 @@ section. By default, the "Positional arguments" section is only displayed if any
 will override this behavior (`hidden=True` will hide args with help text, `hidden=False` will show args with no help
 text)
 
+## Options
+- Options accept `nargs=-1` to consume arbitrary number of values, just like arguments do
+
 ## Option Groups
 - Option groups accept a `post_parse_callback`, which is run after arguments are parsed, and allows manipulation of the
 context. This is useful for more complicated option group factories


### PR DESCRIPTION
Options now can have `nargs=-1` to consume an arbitrary number of values, just like arguments do

Idea/implementation from: https://stackoverflow.com/a/48394004
