### PR TITLE
Allow configuration of "required" tag for options and "optional" tag for arguments in help text

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -3,11 +3,16 @@
 List of changes made to [connormason/cloup](https://github.com/connormason/cloup) that diverge from the default
 [cloup](https://github.com/janluke/cloup) library
 
-## Context Defaults
+## Context
+### Defaults
 - The help text can be accessed with `-h` or `--help` by default (instead of just `-h`). This can be overridden by
 providing the `help_option_names` context option
 - The maximum content width of help text is 500 (so it fills the whole width of the terminal). This can be overridden
 by providing the `max_content_width` context option
+
+### Settings
+- Added `tag_required_options`, which can be set to `False` to disable the "required" tag for required options
+- Added `tag_optional_arguments`, which can be set to `False` to disable the "optional" tag for non-required arguments
 
 ## Arguments
 - Arguments accept `hidden` arg, which determines if the arg is hidden from the "Positional arguments" help text

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -39,7 +39,8 @@ def _warn_if_formatter_settings_conflict(
 
 
 class Context(click.Context):
-    """A custom context for Cloup.
+    """
+    A custom context for Cloup.
 
     Look up :class:`click.Context` for the list of all arguments.
 
@@ -48,32 +49,27 @@ class Context(click.Context):
 
     .. versionadded:: 0.8.0
 
-    :param ctx_args:
-        arguments forwarded to :class:`click.Context`.
-    :param align_option_groups:
-        if True, align the definition lists of all option groups of a command.
-        You can override this by setting the corresponding argument of ``Command``
-        (but you probably shouldn't: be consistent).
-    :param align_sections:
-        if True, align the definition lists of all subcommands of a group.
-        You can override this by setting the corresponding argument of ``Group``
-        (but you probably shouldn't: be consistent).
-    :param show_subcommand_aliases:
-        whether to show the aliases of subcommands in the help of a ``cloup.Group``.
-    :param show_constraints:
-        whether to include a "Constraint" section in the command help (if at
-        least one constraint is defined).
-    :param check_constraints_consistency:
-        enable additional checks for constraints which detects mistakes of the
-        developer (see :meth:`cloup.Constraint.check_consistency`).
-    :param formatter_settings:
-        keyword arguments forwarded to :class:`HelpFormatter` in ``make_formatter``.
-        This args are merged with those of the (eventual) parent context and then
-        merged again (being overridden) by those of the command.
-        **Tip**: use the static method :meth:`HelpFormatter.settings` to create this
-        dictionary, so that you can be guided by your IDE.
-    :param ctx_kwargs:
-        keyword arguments forwarded to :class:`click.Context`.
+    :param ctx_args: arguments forwarded to :class:`click.Context`.
+    :param align_option_groups: if True, align the definition lists of all option groups of a command. You can override
+                                this by setting the corresponding argument of ``Command`` (but you probably shouldn't:
+                                be consistent).
+    :param align_sections: if True, align the definition lists of all subcommands of a group. You can override this
+                           by setting the corresponding argument of ``Group`` (but you probably shouldn't: be
+                           consistent).
+    :param show_subcommand_aliases: whether to show the aliases of subcommands in the help of a ``cloup.Group``.
+    :param show_constraints: whether to include a "Constraint" section in the command help (if at least one constraint
+                             is defined).
+    :param check_constraints_consistency: enable additional checks for constraints which detects mistakes of the
+                                          developer (see :meth:`cloup.Constraint.check_consistency`).
+    :param formatter_settings: keyword arguments forwarded to :class:`HelpFormatter` in ``make_formatter``. This args
+                               are merged with those of the (eventual) parent context and then merged again (being
+                               overridden) by those of the command. **Tip**: use the static method
+                               :meth:`HelpFormatter.settings` to create this dictionary, so that you can be guided by
+                               your IDE.
+    :param tag_required_options: if True, options with `required=True` will be tagged in the help text as "required"
+    :param tag_optional_arguments: if True, arguments with `required=False` will be tagged in the help text
+                                   as "optional"
+    :param ctx_kwargs: keyword arguments forwarded to :class:`click.Context`.
     """
 
     formatter_class: type[HelpFormatter] = HelpFormatter
@@ -88,8 +84,10 @@ class Context(click.Context):
         show_constraints: bool | None = None,
         check_constraints_consistency: bool | None = None,
         formatter_settings: dict[str, Any] = {},
-        max_content_width: int | None = None,                   # Here so we can change the defaults
-        help_option_names: list[str] | None = None,             # Here so we can change the defaults
+        tag_required_options: bool = True,
+        tag_optional_arguments: bool = True,
+        max_content_width: int | None = None,                   # Here so we can change the defaults before super()
+        help_option_names: list[str] | None = None,             # Here so we can change the defaults before super()
         **ctx_kwargs: Any,
     ):
 
@@ -130,7 +128,16 @@ class Context(click.Context):
             getattr(self.parent, 'show_constraints', None),
         )
         self.check_constraints_consistency = coalesce(
-            check_constraints_consistency, getattr(self.parent, 'check_constraints_consistency', None)
+            check_constraints_consistency,
+            getattr(self.parent, 'check_constraints_consistency', None)
+        )
+        self.tag_required_options = coalesce(
+            tag_required_options,
+            getattr(self.parent, 'tag_required_options', None)
+        )
+        self.tag_optional_arguments = coalesce(
+            tag_optional_arguments,
+            getattr(self.parent, 'tag_optional_arguments', None)
         )
 
         if cloup.warnings.formatter_settings_conflict:

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -124,7 +124,11 @@ class Argument(click.Argument):
                 extra.append(range_str)
 
         # If not required, tag as "optional" (opposite of options)
-        if not self.required:
+        tag_optional_arguments = getattr(ctx, 'tag_optional_arguments', True)
+        if tag_optional_arguments is None:
+            tag_optional_arguments = True
+
+        if (not self.required) and tag_optional_arguments:
             extra.append(_('optional'))
 
         # Add extra tags
@@ -295,7 +299,11 @@ class Option(click.Option):
             if range_str:
                 extra.append(range_str)
 
-        if self.required:
+        tag_required_options = getattr(ctx, 'tag_required_options', True)
+        if tag_required_options is None:
+            tag_required_options = True
+
+        if self.required and tag_required_options:
             extra.append(_('required'))
 
         if extra:

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -12,6 +12,7 @@ from typing import Union
 import click
 from click.decorators import _param_memo
 from click.formatting import join_options
+from click.parser import split_opt
 from click.types import _NumberRangeBase
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ class Argument(click.Argument):
         Get data to output in help text
 
         This is implemented to allow the `show_default` option for arguments (similar to options). The code here is
-        mostly pulled from :class:`click.Option.get_help_record`
+        mostly pulled from :meth:`click.Option.get_help_record`
 
         :param ctx: :class:`click.Context`
         """
@@ -192,6 +193,116 @@ class Option(click.Option):
                 self._previous_parser_process = our_parser.process
                 our_parser.process = parser_process
                 break
+
+    def get_help_record(self, ctx: Context) -> tuple[str, str] | None:
+        """
+        Get data to output in help text
+
+        Pulled straight from :meth:`click.Option.get_help_record`, but with minor changes to allow disablement of the
+        "required" tag
+
+        :param ctx: :class:`click.Context`
+        """
+        if self.hidden:
+            return None
+
+        any_prefix_is_slash = False
+
+        def _write_opts(opts: Sequence[str]) -> str:
+            nonlocal any_prefix_is_slash
+            rv, any_slashes = join_options(opts)
+            if any_slashes:
+                any_prefix_is_slash = True
+            if not self.is_flag and not self.count:
+                rv += f' {self.make_metavar()}'
+            return rv
+
+        rv = [_write_opts(self.opts)]
+        if self.secondary_opts:
+            rv.append(_write_opts(self.secondary_opts))
+
+        help = self.help or ''
+        extra = []
+
+        if self.show_envvar:
+            envvar = self.envvar
+            if envvar is None:
+                if (
+                    self.allow_from_autoenv
+                    and ctx.auto_envvar_prefix is not None
+                    and self.name is not None
+                ):
+                    envvar = f'{ctx.auto_envvar_prefix}_{self.name.upper()}'
+
+            if envvar is not None:
+                var_str = (
+                    envvar
+                    if isinstance(envvar, str)
+                    else ', '.join(str(d) for d in envvar)
+                )
+                extra.append(_('env var: {var}').format(var=var_str))
+
+        # Temporarily enable resilient parsing to avoid type casting
+        # failing for the default. Might be possible to extend this to
+        # help formatting in general.
+        resilient = ctx.resilient_parsing
+        ctx.resilient_parsing = True
+
+        try:
+            default_value = self.get_default(ctx, call=False)
+        finally:
+            ctx.resilient_parsing = resilient
+
+        show_default = False
+        show_default_is_str = False
+
+        if self.show_default is not None:
+            if isinstance(self.show_default, str):
+                show_default_is_str = show_default = True
+            else:
+                show_default = self.show_default
+        elif ctx.show_default is not None:
+            show_default = ctx.show_default
+
+        if show_default_is_str or (show_default and (default_value is not None)):
+            if show_default_is_str:
+                default_string = f'({self.show_default})'
+            elif isinstance(default_value, (list, tuple)):
+                default_string = ', '.join(str(d) for d in default_value)
+            elif inspect.isfunction(default_value):
+                default_string = _('(dynamic)')
+            elif self.is_bool_flag and self.secondary_opts:
+                # For boolean flags that have distinct True/False opts,
+                # use the opt without prefix instead of the value.
+                default_string = split_opt(
+                    (self.opts if self.default else self.secondary_opts)[0]
+                )[1]
+            elif self.is_bool_flag and not self.secondary_opts and not default_value:
+                default_string = ''
+            else:
+                default_string = str(default_value)
+
+            if default_string:
+                extra.append(_('default: {default}').format(default=default_string))
+
+        if (
+            isinstance(self.type, _NumberRangeBase)
+            # skip count with default range type
+            and not (self.count and self.type.min == 0 and self.type.max is None)
+        ):
+            range_str = self.type._describe_range()
+
+            if range_str:
+                extra.append(range_str)
+
+        if self.required:
+            extra.append(_('required'))
+
+        if extra:
+            extra_str = '; '.join(extra)
+            help = f'{help}  [{extra_str}]' if help else f'[{extra_str}]'
+
+        return ('; ' if any_prefix_is_slash else ' / ').join(rv), help
 
 
 GroupedOption = Option


### PR DESCRIPTION
Adds context options to control if the required/optional tags are displayed