### PR TITLE
Add custom DateTime type with added functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,8 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
+        additional_dependencies:
+          - types-python-dateutil
         exclude: |
           (?x)(
               ^tests|

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -28,3 +28,10 @@ like options)
 ## Option Groups
 - Option groups accept a `post_parse_callback`, which is run after arguments are parsed, and allows manipulation of the
 context. This is useful for more complicated option group factories
+
+## Parameter Types
+- `DateTime` parameter type supports additional kwargs:
+  - `formats_in_metavar` can be set to `False` to show "DATETIME" as the parameter metavar, instead of the list of
+    supported datetime formats
+  - `use_dateutil` can be set to `True` to use the [python-dateutil](https://github.com/dateutil/dateutil) package for
+    parsing datetimes, instead of explicitly provided datetime formats to use for parsing

--- a/cloup/types.py
+++ b/cloup/types.py
@@ -4,11 +4,14 @@ Parameter types and "shortcuts" for creating commonly used types.
 from __future__ import annotations
 
 import pathlib
+from collections.abc import Sequence
+from datetime import datetime
 from typing import Any
 from typing import TYPE_CHECKING
 
 import click
 from click.types import Choice as _Choice
+from click.types import DateTime as _DateTime
 
 if TYPE_CHECKING:
     from click import Context
@@ -64,7 +67,21 @@ def file_path(
 
 class Choice(_Choice):
     """
-    Same as :class:`click.types.Choice`, but supports nargs=-1 for options
+    The choice type allows a value to be checked against a fixed set of supported values.
+    All of these values have to be strings.
+
+    You should only pass a list or tuple of choices. Other iterables (like generators) may lead to surprising results.
+
+    The resulting value will always be one of the originally passed choices regardless of ``case_sensitive`` or
+    any ``ctx.token_normalize_func`` being specified.
+
+    See :ref:`choice-opts` for an example.
+
+    Implemented in connormason/cloup:
+        - Support for usage with options with nargs=-1 (implemented in our custom Option class)
+
+    :param choices: choices to provide as options
+    :param case_sensitive: Set to false to make choices case insensitive. Defaults to true.
     """
     def convert(self, value: Any, param: Parameter | None, ctx: Context | None) -> str:
         normed_value = value
@@ -103,3 +120,70 @@ class Choice(_Choice):
             return normed_choices[normed_value]
         else:
             return self.fail(f'invalid choice: {value}. (choose from {", ".join(self.choices)})', param, ctx)
+
+
+class DateTime(_DateTime):
+    """
+    The DateTime type converts date strings into `datetime` objects.
+
+    The format strings which are checked are configurable, but default to some common (non-timezone aware)
+    ISO 8601 formats.
+
+    When specifying *DateTime* formats, you should only pass a list or a tuple. Other iterables, like generators, may
+    lead to surprising results.
+
+    The format strings are processed using ``datetime.strptime``, and this consequently defines the format strings
+    which are allowed.
+
+    Parsing is tried using each format, in order, and the first format which parses successfully is used.
+
+    Implemented in connormason/cloup:
+        - Added ``formats_in_metavar`` kwarg
+        - Added ``use_dateutil`` kwarg
+
+    :param formats: a list or tuple of date format strings, in the order in which they should be tried. Defaults to
+                    ``'%Y-%m-%d'``, ``'%Y-%m-%dT%H:%M:%S'``, ``'%Y-%m-%d %H:%M:%S'``.
+    :param formats_in_metavar: if True, datetime formats will be shown as the option metavar. If False, "DATETIME" will
+                               be shown as the option metavar
+    :param use_dateutil: if True, python-dateutil will be used to parse the option value (if it is installed). When
+                         True, the ``formats`` kwarg is ignored
+    """
+    def __init__(
+        self,
+        formats: Sequence[str] | None = None,
+        formats_in_metavar: bool = True,
+        use_dateutil: bool = False
+    ):
+        super().__init__(formats=formats)
+        self.formats_in_metavar = formats_in_metavar
+        self.use_dateutil = use_dateutil
+
+    def to_info_dict(self) -> dict[str, Any]:
+        info_dict = super().to_info_dict()
+        info_dict['use_dateutil'] = self.use_dateutil
+        return info_dict
+
+    def get_metavar(self, param: Parameter) -> str:
+        if self.formats_in_metavar and not self.use_dateutil:
+            return f'[{" | ".join(self.formats)}]'
+        else:
+            return 'DATETIME'
+
+    def convert(self, value: Any, param: Parameter | None, ctx: Context | None) -> Any:
+        if isinstance(value, datetime):
+            return value
+
+        if self.use_dateutil:
+            try:
+                from dateutil.parser import parse as parse_datetime
+            except (ModuleNotFoundError, ImportError, NameError) as e:
+                raise ImportError('python-dateutil must be installed to use_dateutil with click.DateTime') from e
+            else:
+                from dateutil.parser import ParserError
+                try:
+                    return parse_datetime(value)
+                except ParserError:
+                    self.fail(f'{value} is not a valid datetime', param, ctx)
+
+        else:
+            return super().convert(value, param, ctx)


### PR DESCRIPTION
`DateTime` parameter type supports additional kwargs:
- `formats_in_metavar` can be set to `False` to show "DATETIME" as the parameter metavar, instead of the list of supported datetime formats
- `use_dateutil` can be set to `True` to use the [python-dateutil](https://github.com/dateutil/dateutil) package for parsing datetimes, instead of explicitly provided datetime formats to use for parsing
