### PR TITLE
Add Real parameter type that accepts a float or an int

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -44,3 +44,5 @@ context. This is useful for more complicated option group factories
   type can be configured to allow JSON as a raw string provided to the parameter, or a path to a JSON file with the
   `str_ok` and `path_ok` kwargs respectively. `JSONString` and `JSONPath` are just aliases to the `JSON` type with these
   kwargs set by default to their respective values
+- `Real` parameter type added, which accepts either a float or an int (like what is represented by the `numbers.Real`)
+  type

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -64,7 +64,7 @@ from .constraints import (
     constrained_params,
     constraint,
 )
-from .types import dir_path, file_path, path, Choice, DateTime, Integer, JSON, JSONPath, JSONString
+from .types import dir_path, file_path, path, Choice, DateTime, Integer, JSON, JSONPath, JSONString, Real
 
 __all__ = [
     'Argument',
@@ -93,6 +93,7 @@ __all__ = [
     'OptionGroupMixin',
     'ParamType',
     'Path',
+    'Real',
     'STRING',
     'Section',
     'SectionMixin',

--- a/cloup/types.py
+++ b/cloup/types.py
@@ -10,6 +10,7 @@ from gettext import gettext as _
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
+from typing import Union
 
 import click
 from click.types import Choice as _Choice
@@ -22,6 +23,14 @@ from cloup.typing import MISSING
 if TYPE_CHECKING:
     from click import Context
     from click import Parameter
+
+
+"""
+Typing types
+"""
+
+
+RealType = Union[int, float]
 
 
 """
@@ -310,3 +319,26 @@ class JSONPath(JSON):
     """
     def __init__(self, type: type | None = None):
         super().__init__(type=type, str_ok=False)
+
+
+class RealParamType(ParamType):
+    """
+    Parameter type that accepts either a float or an int (like what is represented by the :class:`numbers.Real` type)
+    """
+    name = 'real'
+
+    def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> RealType:
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return self.fail(_(f'{value} is not a valid integer or floating point value'), param, ctx)
+
+    def __repr__(self) -> str:
+        return 'REAL'
+
+
+#: A real number value parameter, like the numbers.Real type
+Real = RealParamType()


### PR DESCRIPTION
Added `Real` type that accepts a float or an int (like the `numbers.Real` type)